### PR TITLE
generateindex - abort if no valid prefix

### DIFF
--- a/lib/bot.php
+++ b/lib/bot.php
@@ -385,6 +385,12 @@ function generateindex($origpage, $archiveprefix, $level)
     global $wpi;
 
     $tmp = extractnamespace($archiveprefix);
+    if (!isset($tmp[1])) {
+        $logger->addError("[" . $origpage . "] failed to get valid prefix for '" .
+                          $archiveprefix . "': " . var_export($tmp, true));
+        return;
+    }
+
     $array = $wpapi->listprefix($tmp[1], namespacetoid($tmp[0]), 500);
     if (is_array($array)) {
         $data = '';


### PR DESCRIPTION
Currently if `$tmp[1]` is null, we start trying to process the first 500
pages in the main namespace... which isn't what should happen.

Add a basic check to ensure we have a valid prefix before trying to
generate the index.
